### PR TITLE
Automatic publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+      - name: Build package
+        run: python -m build
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
This PR automates the publishing process using GitHub actions/releases.

* [x] Add a [workflow to build and publish to PyPI](https://docs.github.com/en/actions/guides/building-and-testing-python#publishing-to-package-registries)
    * Add PyPI token for ``condor_git_config``

The setup is identical to the one used for ``cobald`` (https://github.com/MatterMiners/cobald/pull/97).