### PR TITLE
include "--ff-only" in git pull command

### DIFF
--- a/condor_git_config.py
+++ b/condor_git_config.py
@@ -196,7 +196,10 @@ class ConfigCache(object):
         else:
             try:
                 subprocess.check_output(
-                    ["git", "pull", "--ff-only"], timeout=30, cwd=repo_path, universal_newlines=True
+                    ["git", "pull", "--ff-only"],
+                    timeout=30,
+                    cwd=repo_path,
+                    universal_newlines=True,
                 )
             except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
                 pass

--- a/condor_git_config.py
+++ b/condor_git_config.py
@@ -196,7 +196,7 @@ class ConfigCache(object):
         else:
             try:
                 subprocess.check_output(
-                    ["git", "pull"], timeout=30, cwd=repo_path, universal_newlines=True
+                    ["git", "pull", "--ff-only"], timeout=30, cwd=repo_path, universal_newlines=True
                 )
             except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
                 pass


### PR DESCRIPTION
Dear all,

while testing, including `--ff-only` in line 199 of the python script, did squelch the hint message addressed in issue #13 .

Best wishes,
Roman

Closes #13.